### PR TITLE
Add atoms module: Cs/Rb level structures and composite Hilbert space

### DIFF
--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -1,0 +1,111 @@
+"""Tests for triqg.atoms -- atomic level structures and composite Hilbert space."""
+
+import pytest
+from triqg.atoms import CsAtom, RbAtom, composite_basis_state, composite_projector, DIMS
+
+
+class TestCsAtom:
+    def test_has_three_levels(self):
+        atom = CsAtom()
+        assert atom.num_levels == 3
+
+    def test_level_labels(self):
+        atom = CsAtom()
+        assert atom.labels == ["0", "1", "r"]
+
+    def test_level_index_lookup(self):
+        atom = CsAtom()
+        assert atom.level_index["0"] == 0
+        assert atom.level_index["1"] == 1
+        assert atom.level_index["r"] == 2
+
+
+class TestRbAtom:
+    def test_has_four_levels(self):
+        atom = RbAtom()
+        assert atom.num_levels == 4
+
+    def test_level_labels(self):
+        atom = RbAtom()
+        assert atom.labels == ["A", "B", "P", "R"]
+
+    def test_level_index_lookup(self):
+        atom = RbAtom()
+        assert atom.level_index["A"] == 0
+        assert atom.level_index["B"] == 1
+        assert atom.level_index["P"] == 2
+        assert atom.level_index["R"] == 3
+
+
+class TestCompositeBasisState:
+    def test_total_dimension(self):
+        """3 x 3 x 4 = 36 dimensional Hilbert space."""
+        assert DIMS == [3, 3, 4]
+
+    def test_basis_state_shape(self):
+        psi = composite_basis_state(0, 0, 0)
+        assert psi.shape == (36, 1)
+
+    def test_basis_state_is_ket(self):
+        psi = composite_basis_state(0, 0, 0)
+        assert psi.isket
+
+    def test_basis_state_is_normalized(self):
+        psi = composite_basis_state(1, 2, 3)
+        assert psi.norm() == pytest.approx(1.0)
+
+    def test_all_36_basis_states_are_orthonormal(self):
+        """Every pair of distinct basis states has zero overlap."""
+        states = []
+        for c1 in range(DIMS[0]):
+            for c2 in range(DIMS[1]):
+                for t in range(DIMS[2]):
+                    states.append(composite_basis_state(c1, c2, t))
+        assert len(states) == 36
+        for i, si in enumerate(states):
+            for j, sj in enumerate(states):
+                overlap = abs(si.overlap(sj))
+                if i == j:
+                    assert overlap == pytest.approx(1.0)
+                else:
+                    assert overlap == pytest.approx(0.0)
+
+
+class TestCompositeProjector:
+    def test_projector_shape(self):
+        """Projector for control1, level 0 should be 36x36."""
+        P = composite_projector(subsystem=0, level=0)
+        assert P.shape == (36, 36)
+
+    def test_projector_is_operator(self):
+        P = composite_projector(subsystem=0, level=0)
+        assert P.isoper
+
+    def test_projector_trace_is_one_per_degeneracy(self):
+        """Tr(|0><0|_c1 ⊗ I_c2 ⊗ I_t) = 1 * 3 * 4 = 12."""
+        P = composite_projector(subsystem=0, level=0)
+        assert float(P.tr().real) == pytest.approx(12.0)
+
+    def test_projector_is_idempotent(self):
+        P = composite_projector(subsystem=2, level=3)
+        diff = P * P - P
+        assert diff.norm() < 1e-12
+
+    def test_projector_is_hermitian(self):
+        P = composite_projector(subsystem=1, level=2)
+        diff = P - P.dag()
+        assert diff.norm() < 1e-12
+
+    def test_subsystem_projectors_sum_to_identity(self):
+        """Sum of projectors over all levels of one subsystem = I_36."""
+        import qutip
+
+        identity_36 = qutip.tensor(
+            qutip.qeye(DIMS[0]),
+            qutip.qeye(DIMS[1]),
+            qutip.qeye(DIMS[2]),
+        )
+        for sub in range(3):
+            total = sum(composite_projector(sub, lev) for lev in range(DIMS[sub]))
+            diff = total - identity_36
+            assert diff.norm() < 1e-12, f"subsystem {sub} projectors don't sum to I"

--- a/triqg/__init__.py
+++ b/triqg/__init__.py
@@ -3,3 +3,12 @@ TriQG - Pulse-level simulation of atomic quantum systems.
 """
 
 __version__ = "0.1.0"
+
+from .atoms import (
+    Atom,
+    CsAtom,
+    RbAtom,
+    DIMS,
+    composite_basis_state,
+    composite_projector,
+)

--- a/triqg/atoms.py
+++ b/triqg/atoms.py
@@ -1,0 +1,92 @@
+"""
+Atomic level structures and composite Hilbert space for Rydberg gate simulations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+import qutip
+
+
+@dataclass(frozen=True)
+class Atom:
+    """An atom with a fixed number of energy levels."""
+
+    num_levels: int
+    labels: List[str]
+    level_index: Dict[str, int] = field(init=False, repr=False)
+
+    def __post_init__(self):
+        # frozen=True requires object.__setattr__ for init
+        object.__setattr__(
+            self,
+            "level_index",
+            {label: i for i, label in enumerate(self.labels)},
+        )
+
+
+def CsAtom() -> Atom:
+    """133-Cs control atom: |0>, |1>, |r>."""
+    return Atom(num_levels=3, labels=["0", "1", "r"])
+
+
+def RbAtom() -> Atom:
+    """87-Rb target atom: |A>, |B>, |P>, |R>."""
+    return Atom(num_levels=4, labels=["A", "B", "P", "R"])
+
+
+# Composite Hilbert space dimensions: control1 x control2 x target
+DIMS = [3, 3, 4]
+
+
+def composite_basis_state(c1: int, c2: int, target: int) -> qutip.Qobj:
+    """
+    Construct a basis state in the composite 3x3x4 Hilbert space.
+
+    Parameters
+    ----------
+    c1 : int
+        Level index for control atom 1 (0, 1, or 2).
+    c2 : int
+        Level index for control atom 2 (0, 1, or 2).
+    target : int
+        Level index for the target atom (0, 1, 2, or 3).
+
+    Returns
+    -------
+    qutip.Qobj
+        A ket in the 36-dimensional composite space.
+    """
+    return qutip.tensor(
+        qutip.basis(DIMS[0], c1),
+        qutip.basis(DIMS[1], c2),
+        qutip.basis(DIMS[2], target),
+    )
+
+
+def composite_projector(subsystem: int, level: int) -> qutip.Qobj:
+    """
+    Construct |level><level| for one subsystem, tensored with identity on others.
+
+    Parameters
+    ----------
+    subsystem : int
+        0 = control1, 1 = control2, 2 = target.
+    level : int
+        Level index within the subsystem.
+
+    Returns
+    -------
+    qutip.Qobj
+        A 36x36 projector operator in the composite space.
+    """
+    ops = []
+    for i, dim in enumerate(DIMS):
+        if i == subsystem:
+            ket = qutip.basis(dim, level)
+            ops.append(ket * ket.dag())
+        else:
+            ops.append(qutip.qeye(dim))
+    return qutip.tensor(ops)


### PR DESCRIPTION
## Summary

- Implements `triqg/atoms.py` with `CsAtom` (3-level: |0>, |1>, |r>), `RbAtom` (4-level: |A>, |B>, |P>, |R>), `composite_basis_state` for the 36-dim tensor product space, and `composite_projector` for embedding single-atom projectors
- Adds 17 tests in `tests/test_atoms.py` covering atom structure, basis state orthonormality, and projector properties (shape, trace, idempotence, Hermiticity, sum-to-identity)
- Exports public API from `triqg/__init__.py`

Closes #2
