### PR TITLE
Add pulses module: control, target, and coupling pulse shapes with area helper

### DIFF
--- a/tests/test_pulses.py
+++ b/tests/test_pulses.py
@@ -1,0 +1,146 @@
+"""Tests for triqg.pulses -- pulse shapes and area helper."""
+
+import numpy as np
+import pytest
+
+from triqg.pulses import omega_c, omega_p, omega_R, compute_pulse_area
+
+
+# Shared test parameters
+ARGS = {
+    "omega_c_amp": 2 * np.pi * 50,  # 2pi * 50 MHz
+    "omega_p_amp": 2 * np.pi * 50,
+    "omega_R_amp": 2.5 * 2 * np.pi * 50,
+    "T_c": np.pi / (2 * np.pi * 50),  # pi / Omega_c
+    "T_f": 0.5,  # arbitrary for now
+    "sigma": 0.05,
+}
+
+
+class TestOmegaC:
+    def test_positive_segment(self):
+        """omega_c returns +amp/2 in [0, T_c)."""
+        amp = ARGS["omega_c_amp"]
+        T_c = ARGS["T_c"]
+        # sample at the midpoint of the first segment
+        t_mid = T_c / 2
+        assert omega_c(t_mid, ARGS) == pytest.approx(amp / 2)
+
+    def test_gap_segment_is_zero(self):
+        """omega_c returns 0 in [T_c, T_c + T_f)."""
+        T_c = ARGS["T_c"]
+        T_f = ARGS["T_f"]
+        t_gap = T_c + T_f / 2
+        assert omega_c(t_gap, ARGS) == pytest.approx(0.0)
+
+    def test_negative_segment(self):
+        """omega_c returns -amp/2 in [T_c + T_f, 2*T_c + T_f)."""
+        amp = ARGS["omega_c_amp"]
+        T_c = ARGS["T_c"]
+        T_f = ARGS["T_f"]
+        t_neg = T_c + T_f + T_c / 2
+        assert omega_c(t_neg, ARGS) == pytest.approx(-amp / 2)
+
+    def test_zero_before_start(self):
+        assert omega_c(-0.1, ARGS) == pytest.approx(0.0)
+
+    def test_zero_after_end(self):
+        T_c = ARGS["T_c"]
+        T_f = ARGS["T_f"]
+        assert omega_c(2 * T_c + T_f + 0.1, ARGS) == pytest.approx(0.0)
+
+
+class TestOmegaP:
+    def test_zero_before_window(self):
+        """omega_p returns 0 before T_c."""
+        assert omega_p(0.0, ARGS) == pytest.approx(0.0)
+
+    def test_zero_after_window(self):
+        """omega_p returns 0 after T_c + T_f."""
+        T_c = ARGS["T_c"]
+        T_f = ARGS["T_f"]
+        assert omega_p(T_c + T_f + 0.01, ARGS) == pytest.approx(0.0)
+
+    def test_peak_at_center(self):
+        """At center = T_c + T_f/2, the exponent is 0 so value = amp/2."""
+        amp = ARGS["omega_p_amp"]
+        T_c = ARGS["T_c"]
+        T_f = ARGS["T_f"]
+        center = T_c + T_f / 2
+        assert omega_p(center, ARGS) == pytest.approx(amp / 2)
+
+    def test_symmetric_near_center(self):
+        """Pulse is NOT symmetric (cubic exponent), but |value| decreases away from center."""
+        T_c = ARGS["T_c"]
+        T_f = ARGS["T_f"]
+        center = T_c + T_f / 2
+        val_center = omega_p(center, ARGS)
+        val_offset = omega_p(center + 0.01, ARGS)
+        assert abs(val_offset) < abs(val_center)
+
+
+class TestOmegaR:
+    def test_constant_inside_window(self):
+        """omega_R returns amp/2 during [T_c, T_c + T_f)."""
+        amp = ARGS["omega_R_amp"]
+        T_c = ARGS["T_c"]
+        T_f = ARGS["T_f"]
+        t_mid = T_c + T_f / 2
+        assert omega_R(t_mid, ARGS) == pytest.approx(amp / 2)
+
+    def test_zero_before_window(self):
+        assert omega_R(0.0, ARGS) == pytest.approx(0.0)
+
+    def test_zero_after_window(self):
+        T_c = ARGS["T_c"]
+        T_f = ARGS["T_f"]
+        assert omega_R(T_c + T_f + 0.01, ARGS) == pytest.approx(0.0)
+
+
+class TestComputePulseArea:
+    def test_constant_pulse_exact_area(self):
+        """
+        For a constant pulse f(t)=A over [0, T], area = A^2 * T / (2*delta).
+        Choose A, T, delta so the analytic result is known.
+        """
+        A = 10.0
+        delta = 5.0
+        T = 2.0
+        expected_area = A**2 * T / (2 * delta)  # 10^2 * 2 / 10 = 20
+
+        def const_pulse(t, args):
+            return A
+
+        area = compute_pulse_area(const_pulse, delta, 0.0, T, args={})
+        assert area == pytest.approx(expected_area, rel=1e-6)
+
+    def test_zero_pulse_gives_zero_area(self):
+        def zero_pulse(t, args):
+            return 0.0
+
+        area = compute_pulse_area(zero_pulse, 1.0, 0.0, 1.0, args={})
+        assert area == pytest.approx(0.0)
+
+
+class TestQuTiPCompatibility:
+    def test_omega_c_works_as_qobjevo_coefficient(self):
+        """Pulse functions can be used as QuTiP [Qobj, func] coefficients."""
+        import qutip
+
+        H0 = qutip.sigmaz()
+        H1 = qutip.sigmax()
+        # This should not raise -- QobjEvo accepts f(t, args) callables
+        H = qutip.QobjEvo([H0, [H1, omega_c]], args=ARGS)
+        # Evaluate at a time in the first segment -- should return H0 + (amp/2)*H1
+        result = H(ARGS["T_c"] / 2)
+        assert result.shape == (2, 2)
+
+    def test_omega_p_works_as_qobjevo_coefficient(self):
+        import qutip
+
+        H0 = qutip.sigmaz()
+        H1 = qutip.sigmax()
+        H = qutip.QobjEvo([H0, [H1, omega_p]], args=ARGS)
+        center = ARGS["T_c"] + ARGS["T_f"] / 2
+        result = H(center)
+        assert result.shape == (2, 2)

--- a/triqg/__init__.py
+++ b/triqg/__init__.py
@@ -12,3 +12,10 @@ from .atoms import (
     composite_basis_state,
     composite_projector,
 )
+
+from .pulses import (
+    omega_c,
+    omega_p,
+    omega_R,
+    compute_pulse_area,
+)

--- a/triqg/pulses.py
+++ b/triqg/pulses.py
@@ -1,0 +1,112 @@
+"""
+Pulse shape functions for Rydberg gate simulations.
+
+All pulse functions have signature ``f(t, args) -> float``, compatible
+with QuTiP's ``[Qobj, func]`` time-dependent coefficient format.
+
+Expected keys in ``args``:
+    omega_c_amp, omega_p_amp, omega_R_amp, T_c, T_f, sigma
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+from scipy import integrate
+
+
+def omega_c(t: float, args: dict) -> float:
+    """
+    Piecewise square control pulse on |1> <-> |r>.
+
+    Segments:
+        [0, T_c)            : +omega_c_amp / 2
+        [T_c, T_c + T_f)    : 0
+        [T_c+T_f, 2*T_c+T_f): -omega_c_amp / 2
+        otherwise            : 0
+    """
+    amp = args["omega_c_amp"]
+    T_c = args["T_c"]
+    T_f = args["T_f"]
+
+    if 0 <= t < T_c:
+        return amp / 2
+    elif T_c + T_f <= t < 2 * T_c + T_f:
+        return -amp / 2
+    else:
+        return 0.0
+
+
+def omega_p(t: float, args: dict) -> float:
+    """
+    Cubic super-Gaussian target pulse on |A>,|B> <-> |P>.
+
+    Active during [T_c, T_c + T_f).
+    Shape: (omega_p_amp / 2) * exp(-((t - center)^3 / sigma)^2)
+    where center = T_c + T_f / 2.
+    """
+    amp = args["omega_p_amp"]
+    T_c = args["T_c"]
+    T_f = args["T_f"]
+    sigma = args["sigma"]
+
+    if T_c <= t < T_c + T_f:
+        center = T_c + T_f / 2
+        return (amp / 2) * np.exp(-((((t - center) ** 3) / sigma) ** 2))
+    else:
+        return 0.0
+
+
+def omega_R(t: float, args: dict) -> float:
+    """
+    Constant resonant coupling on |P> <-> |R> during the target window.
+
+    Active during [T_c, T_c + T_f), returns omega_R_amp / 2.
+    """
+    T_c = args["T_c"]
+    T_f = args["T_f"]
+    amp = args["omega_R_amp"]
+
+    if T_c <= t < T_c + T_f:
+        return amp / 2
+    else:
+        return 0.0
+
+
+def compute_pulse_area(
+    pulse_func: Callable,
+    delta: float,
+    t_start: float,
+    t_end: float,
+    args: dict,
+) -> float:
+    """
+    Numerically integrate pulse_func(t, args)^2 / (2 * delta) over [t_start, t_end].
+
+    This computes the effective two-photon Rabi angle for an off-resonant
+    transition with detuning ``delta``.
+
+    Parameters
+    ----------
+    pulse_func : callable
+        Pulse function with signature ``f(t, args) -> float``.
+    delta : float
+        Detuning (same units as pulse amplitude).
+    t_start, t_end : float
+        Integration bounds.
+    args : dict
+        Arguments forwarded to ``pulse_func``.
+
+    Returns
+    -------
+    float
+        The integrated area (should equal pi for a pi-pulse).
+    """
+
+    def integrand(t):
+        val = pulse_func(t, args)
+        return val**2 / (2 * delta)
+
+    result, _ = integrate.quad(integrand, t_start, t_end)
+    return result


### PR DESCRIPTION
## Summary

- Implements `triqg/pulses.py` with three QuTiP-compatible pulse functions (`omega_c`, `omega_p`, `omega_R`) and a numerical pulse area verifier (`compute_pulse_area`)
- `omega_c(t, args)`: piecewise square control pulse (+amp/2, 0, -amp/2 segments)
- `omega_p(t, args)`: cubic super-Gaussian target pulse `(amp/2) * exp(-((t-center)^3 / sigma)^2)`
- `omega_R(t, args)`: constant coupling during target window
- `compute_pulse_area`: integrates `f(t)^2 / (2*delta)` via `scipy.integrate.quad`
- All functions use `f(t, args) -> float` signature, verified working with `qutip.QobjEvo`
- Adds 16 tests in `tests/test_pulses.py` covering segment values, boundaries, area calculation, and QuTiP integration
- Exports public API from `triqg/__init__.py`

Closes #3
