### PR TITLE
Add decoherence module: collapse operators with branching ratios

### DIFF
--- a/tests/test_decoherence.py
+++ b/tests/test_decoherence.py
@@ -1,0 +1,160 @@
+"""Tests for triqg.decoherence -- collapse operators for decay channels."""
+
+import numpy as np
+import pytest
+import qutip
+
+from triqg.decoherence import build_collapse_operators
+from triqg.atoms import composite_basis_state, CsAtom, RbAtom
+
+
+# Physical decay rates (in MHz, consistent with pulse units)
+GAMMA_r = 1.0 / 548.0  # Cs Rydberg |r> lifetime 548 us
+GAMMA_R = 1.0 / 505.0  # Rb Rydberg |R> lifetime 505 us
+GAMMA_P = 1.0 / 0.131  # Rb intermediate |P> lifetime 0.131 us
+
+
+class TestBuildCollapseOperators:
+    def test_returns_list_of_eight_operators(self):
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P)
+        assert isinstance(c_ops, list)
+        assert len(c_ops) == 8
+
+    def test_all_operators_are_36x36(self):
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P)
+        for i, op in enumerate(c_ops):
+            assert isinstance(op, qutip.Qobj), f"c_ops[{i}] not Qobj"
+            assert op.shape == (36, 36), f"c_ops[{i}] wrong shape"
+
+    def test_default_branching_rate_scaling(self):
+        """
+        With default 0.5/0.5 branching, applying c_ops[0] to a state where
+        control 1 is in |r> should produce a state with norm sqrt(gamma_r * 0.5).
+
+        c_ops[0] |r, 0, A> = sqrt(gamma_r * 0.5) * |0, 0, A>
+        """
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P)
+        psi_r = composite_basis_state(2, 0, 0)  # |r, 0, A>
+        result = c_ops[0] * psi_r
+        expected_norm = np.sqrt(GAMMA_r * 0.5)
+        assert result.norm() == pytest.approx(expected_norm, rel=1e-6)
+
+
+class TestCollapseTransitions:
+    """Verify each operator maps the correct |initial> to the correct |final>."""
+
+    cs = CsAtom()
+    rb = RbAtom()
+    IDX_0 = cs.level_index["0"]
+    IDX_1 = cs.level_index["1"]
+    IDX_r = cs.level_index["r"]
+    IDX_A = rb.level_index["A"]
+    IDX_B = rb.level_index["B"]
+    IDX_P = rb.level_index["P"]
+    IDX_R = rb.level_index["R"]
+
+    def _applied_direction(self, c_op, initial_state, expected_final):
+        """
+        Check that c_op * |initial> is proportional to |final>,
+        i.e. the overlap |<final|result>| / ||result|| == 1.
+        """
+        result = c_op * initial_state
+        if result.norm() < 1e-15:
+            return False  # operator annihilates this state
+        result_normed = result.unit()
+        overlap = abs(expected_final.dag() * result_normed)
+        return float(overlap) > 0.999
+
+    def test_c1_r_to_0(self):
+        """c_ops[0]: control 1 |r> -> |0>."""
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P)
+        initial = composite_basis_state(self.IDX_r, self.IDX_0, self.IDX_A)
+        final = composite_basis_state(self.IDX_0, self.IDX_0, self.IDX_A)
+        assert self._applied_direction(c_ops[0], initial, final)
+
+    def test_c1_r_to_1(self):
+        """c_ops[1]: control 1 |r> -> |1>."""
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P)
+        initial = composite_basis_state(self.IDX_r, self.IDX_0, self.IDX_A)
+        final = composite_basis_state(self.IDX_1, self.IDX_0, self.IDX_A)
+        assert self._applied_direction(c_ops[1], initial, final)
+
+    def test_c2_r_to_0(self):
+        """c_ops[2]: control 2 |r> -> |0>."""
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P)
+        initial = composite_basis_state(self.IDX_0, self.IDX_r, self.IDX_A)
+        final = composite_basis_state(self.IDX_0, self.IDX_0, self.IDX_A)
+        assert self._applied_direction(c_ops[2], initial, final)
+
+    def test_c2_r_to_1(self):
+        """c_ops[3]: control 2 |r> -> |1>."""
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P)
+        initial = composite_basis_state(self.IDX_0, self.IDX_r, self.IDX_A)
+        final = composite_basis_state(self.IDX_0, self.IDX_1, self.IDX_A)
+        assert self._applied_direction(c_ops[3], initial, final)
+
+    def test_target_R_to_A(self):
+        """c_ops[4]: target |R> -> |A>."""
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P)
+        initial = composite_basis_state(self.IDX_0, self.IDX_0, self.IDX_R)
+        final = composite_basis_state(self.IDX_0, self.IDX_0, self.IDX_A)
+        assert self._applied_direction(c_ops[4], initial, final)
+
+    def test_target_R_to_B(self):
+        """c_ops[5]: target |R> -> |B>."""
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P)
+        initial = composite_basis_state(self.IDX_0, self.IDX_0, self.IDX_R)
+        final = composite_basis_state(self.IDX_0, self.IDX_0, self.IDX_B)
+        assert self._applied_direction(c_ops[5], initial, final)
+
+    def test_target_P_to_A(self):
+        """c_ops[6]: target |P> -> |A>."""
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P)
+        initial = composite_basis_state(self.IDX_0, self.IDX_0, self.IDX_P)
+        final = composite_basis_state(self.IDX_0, self.IDX_0, self.IDX_A)
+        assert self._applied_direction(c_ops[6], initial, final)
+
+    def test_target_P_to_B(self):
+        """c_ops[7]: target |P> -> |B>."""
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P)
+        initial = composite_basis_state(self.IDX_0, self.IDX_0, self.IDX_P)
+        final = composite_basis_state(self.IDX_0, self.IDX_0, self.IDX_B)
+        assert self._applied_direction(c_ops[7], initial, final)
+
+    def test_operator_annihilates_wrong_initial(self):
+        """c_ops[0] (|r>->|0> on c1) applied to |0,0,A> should give zero."""
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P)
+        wrong_state = composite_basis_state(self.IDX_0, self.IDX_0, self.IDX_A)
+        result = c_ops[0] * wrong_state
+        assert result.norm() < 1e-15
+
+
+class TestCustomBranching:
+    def test_asymmetric_branching_changes_rate(self):
+        """
+        With branching r=(0.8, 0.2), the |r>->|0> channel (c_ops[0])
+        should have norm sqrt(gamma_r * 0.8) when applied to |r,0,A>,
+        and |r>->|1> (c_ops[1]) should have norm sqrt(gamma_r * 0.2).
+        """
+        custom = {"r": (0.8, 0.2), "R": (0.5, 0.5), "P": (0.5, 0.5)}
+        c_ops = build_collapse_operators(GAMMA_r, GAMMA_R, GAMMA_P, branching=custom)
+
+        psi = composite_basis_state(2, 0, 0)  # |r, 0, A>
+
+        result_0 = c_ops[0] * psi  # |r> -> |0>
+        assert result_0.norm() == pytest.approx(np.sqrt(GAMMA_r * 0.8), rel=1e-6)
+
+        result_1 = c_ops[1] * psi  # |r> -> |1>
+        assert result_1.norm() == pytest.approx(np.sqrt(GAMMA_r * 0.2), rel=1e-6)
+
+
+class TestZeroRate:
+    def test_zero_gamma_gives_zero_operators(self):
+        """When gamma_r=0, control collapse operators should be zero."""
+        c_ops = build_collapse_operators(0.0, GAMMA_R, GAMMA_P)
+        # First 4 operators are control channels
+        for i in range(4):
+            assert c_ops[i].norm() < 1e-15, f"c_ops[{i}] should be zero"
+        # Target operators should still be nonzero
+        for i in range(4, 8):
+            assert c_ops[i].norm() > 1e-15, f"c_ops[{i}] should be nonzero"

--- a/triqg/__init__.py
+++ b/triqg/__init__.py
@@ -21,3 +21,5 @@ from .pulses import (
 )
 
 from .hamiltonian import build_hamiltonian
+
+from .decoherence import build_collapse_operators

--- a/triqg/decoherence.py
+++ b/triqg/decoherence.py
@@ -1,0 +1,95 @@
+"""
+Collapse operators for decay channels in the Rydberg gate simulation.
+
+Builds a flat list of collapse operators embedded in the 36-dim
+composite Hilbert space, suitable for passing to ``mesolve`` / ``mcsolve``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import qutip
+
+from .atoms import CsAtom, RbAtom, DIMS
+
+
+def _collapse_op(
+    subsystem: int, final: int, initial: int, rate: float, branching: float
+) -> qutip.Qobj:
+    """
+    Build sqrt(rate * branching) * |final><initial| on one subsystem,
+    tensored with identity on the others.
+    """
+    ops = []
+    for s, dim in enumerate(DIMS):
+        if s == subsystem:
+            ops.append(qutip.basis(dim, final) * qutip.basis(dim, initial).dag())
+        else:
+            ops.append(qutip.qeye(dim))
+    return np.sqrt(rate * branching) * qutip.tensor(ops)
+
+
+def build_collapse_operators(
+    gamma_r: float,
+    gamma_R: float,
+    gamma_P: float,
+    branching: Optional[Dict[str, Tuple[float, float]]] = None,
+) -> List[qutip.Qobj]:
+    """
+    Build all collapse operators for the three-atom system.
+
+    Parameters
+    ----------
+    gamma_r : float
+        Decay rate of control Rydberg state |r> (1 / lifetime).
+    gamma_R : float
+        Decay rate of target Rydberg state |R>.
+    gamma_P : float
+        Decay rate of target intermediate state |P>.
+    branching : dict, optional
+        Override branching ratios. Keys: "r", "R", "P".
+        Values: (ratio_to_first_ground, ratio_to_second_ground).
+        Default: equal branching (0.5, 0.5) for all channels.
+
+    Returns
+    -------
+    list of qutip.Qobj
+        8 collapse operators (36x36 each).
+    """
+    cs = CsAtom()
+    rb = RbAtom()
+
+    idx_0 = cs.level_index["0"]
+    idx_1 = cs.level_index["1"]
+    idx_r = cs.level_index["r"]
+    idx_A = rb.level_index["A"]
+    idx_B = rb.level_index["B"]
+    idx_P = rb.level_index["P"]
+    idx_R = rb.level_index["R"]
+
+    br = branching or {}
+    br_r = br.get("r", (0.5, 0.5))
+    br_R = br.get("R", (0.5, 0.5))
+    br_P = br.get("P", (0.5, 0.5))
+
+    c_ops = []
+
+    # Control 1: |r> -> |0>, |r> -> |1>
+    c_ops.append(_collapse_op(0, idx_0, idx_r, gamma_r, br_r[0]))
+    c_ops.append(_collapse_op(0, idx_1, idx_r, gamma_r, br_r[1]))
+
+    # Control 2: |r> -> |0>, |r> -> |1>
+    c_ops.append(_collapse_op(1, idx_0, idx_r, gamma_r, br_r[0]))
+    c_ops.append(_collapse_op(1, idx_1, idx_r, gamma_r, br_r[1]))
+
+    # Target: |R> -> |A>, |R> -> |B>
+    c_ops.append(_collapse_op(2, idx_A, idx_R, gamma_R, br_R[0]))
+    c_ops.append(_collapse_op(2, idx_B, idx_R, gamma_R, br_R[1]))
+
+    # Target: |P> -> |A>, |P> -> |B>
+    c_ops.append(_collapse_op(2, idx_A, idx_P, gamma_P, br_P[0]))
+    c_ops.append(_collapse_op(2, idx_B, idx_P, gamma_P, br_P[1]))
+
+    return c_ops


### PR DESCRIPTION
## Summary

- Implements `triqg/decoherence.py` with `build_collapse_operators(gamma_r, gamma_R, gamma_P, branching=None)`
- Returns 8 collapse operators (36x36 each) for all decay channels:
  - Control 1 & 2: |r> -> |0>, |r> -> |1> (rate gamma_r)
  - Target: |R> -> |A>, |R> -> |B> (rate gamma_R)
  - Target: |P> -> |A>, |P> -> |B> (rate gamma_P)
- Each operator is `sqrt(gamma * branching_ratio) * |final><initial|` embedded in the composite space
- Default equal branching (0.5/0.5); custom ratios via `branching={"r": (0.8, 0.2), ...}`
- 14 tests covering operator count, dimensions, rate scaling, all 8 transition directions, custom branching, zero-rate behavior
- Exports `build_collapse_operators` from `triqg/__init__.py`

Closes #5
