### PR TITLE
Add analysis module: state fidelity and population extraction

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,77 @@
+"""Tests for triqg.analysis -- fidelity and population extraction."""
+
+import numpy as np
+import pytest
+import qutip
+
+from triqg.analysis import state_fidelity, extract_populations
+
+
+class TestStateFidelity:
+    def test_ket_fidelity_with_itself_is_one(self):
+        psi = qutip.basis(2, 0)
+        assert state_fidelity(psi, psi) == pytest.approx(1.0)
+
+    def test_ket_fidelity_orthogonal_is_zero(self):
+        psi0 = qutip.basis(2, 0)
+        psi1 = qutip.basis(2, 1)
+        assert state_fidelity(psi0, psi1) == pytest.approx(0.0, abs=1e-10)
+
+    def test_density_matrix_fidelity_with_itself_is_one(self):
+        rho = qutip.ket2dm(qutip.basis(3, 1))
+        assert state_fidelity(rho, rho) == pytest.approx(1.0)
+
+    def test_density_matrix_fidelity_orthogonal_is_zero(self):
+        rho0 = qutip.ket2dm(qutip.basis(3, 0))
+        rho1 = qutip.ket2dm(qutip.basis(3, 2))
+        assert state_fidelity(rho0, rho1) == pytest.approx(0.0, abs=1e-10)
+
+    def test_mixed_ket_and_dm_inputs(self):
+        """Fidelity works when one input is a ket and the other is a dm."""
+        psi = qutip.basis(2, 0)
+        rho = qutip.ket2dm(psi)
+        assert state_fidelity(psi, rho) == pytest.approx(1.0)
+        assert state_fidelity(rho, psi) == pytest.approx(1.0)
+
+    def test_superposition_fidelity(self):
+        """Fidelity of |0> with (|0>+|1>)/sqrt(2) should be 0.5."""
+        psi0 = qutip.basis(2, 0)
+        psi_plus = (qutip.basis(2, 0) + qutip.basis(2, 1)).unit()
+        assert state_fidelity(psi0, psi_plus) == pytest.approx(0.5, abs=1e-10)
+
+
+class TestExtractPopulations:
+    def test_returns_correct_shape(self):
+        """
+        Given a result with 3 expect arrays of length 10,
+        extract_populations(result, 3) should return shape (3, 10).
+        """
+
+        # Simulate a result-like object with .expect attribute
+        class FakeResult:
+            expect = [np.ones(10), np.zeros(10), 0.5 * np.ones(10)]
+
+        pops = extract_populations(FakeResult(), 3)
+        assert pops.shape == (3, 10)
+
+    def test_returns_correct_values(self):
+        """Values should match the input expect arrays."""
+        arr0 = np.array([1.0, 0.8, 0.5, 0.2, 0.0])
+        arr1 = np.array([0.0, 0.2, 0.5, 0.8, 1.0])
+
+        class FakeResult:
+            expect = [arr0, arr1]
+
+        pops = extract_populations(FakeResult(), 2)
+        np.testing.assert_array_almost_equal(pops[0], arr0)
+        np.testing.assert_array_almost_equal(pops[1], arr1)
+
+    def test_takes_real_part(self):
+        """Populations should be real even if expect has small imaginary parts."""
+        arr = np.array([1.0 + 1e-15j, 0.5 + 1e-14j])
+
+        class FakeResult:
+            expect = [arr]
+
+        pops = extract_populations(FakeResult(), 1)
+        assert pops.dtype == np.float64

--- a/triqg/__init__.py
+++ b/triqg/__init__.py
@@ -23,3 +23,5 @@ from .pulses import (
 from .hamiltonian import build_hamiltonian
 
 from .decoherence import build_collapse_operators
+
+from .analysis import state_fidelity, extract_populations

--- a/triqg/analysis.py
+++ b/triqg/analysis.py
@@ -1,0 +1,63 @@
+"""
+Analysis utilities for Rydberg gate simulations.
+
+Provides state fidelity computation and population extraction
+from QuTiP solver results.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+import qutip
+
+
+def state_fidelity(final: qutip.Qobj, target: qutip.Qobj) -> float:
+    """
+    Compute the fidelity between two quantum states.
+
+    For kets: F = |<target|final>|^2.
+    For density matrices: F = (Tr sqrt(sqrt(rho_t) rho_f sqrt(rho_t)))^2,
+    computed via ``qutip.fidelity``.
+
+    Parameters
+    ----------
+    final : qutip.Qobj
+        The state to evaluate (ket or density matrix).
+    target : qutip.Qobj
+        The reference state (ket or density matrix).
+
+    Returns
+    -------
+    float
+        Fidelity in [0, 1].
+    """
+    # Convert kets to density matrices for uniform handling
+    rho_f = qutip.ket2dm(final) if final.isket else final
+    rho_t = qutip.ket2dm(target) if target.isket else target
+
+    return float(qutip.fidelity(rho_f, rho_t) ** 2)
+
+
+def extract_populations(result, num_levels: int) -> np.ndarray:
+    """
+    Extract population data from a QuTiP solver result.
+
+    Assumes the first ``num_levels`` entries in ``result.expect`` are
+    expectation values of population projectors (diagonal elements).
+
+    Parameters
+    ----------
+    result : QuTiP Result or any object with ``.expect`` attribute
+        Solver result. ``result.expect`` should be a list of arrays,
+        where each array has length ``len(tlist)``.
+    num_levels : int
+        Number of population levels to extract.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(num_levels, len(tlist))`` array of real populations.
+    """
+    return np.array([np.real(result.expect[i]) for i in range(num_levels)])


### PR DESCRIPTION
## Summary

- Implements `triqg/analysis.py` with two functions:
  - `state_fidelity(final, target)` -- computes F = (Tr sqrt(sqrt(rho_t) rho_f sqrt(rho_t)))^2 via `qutip.fidelity`; accepts kets, density matrices, or mixed inputs
  - `extract_populations(result, num_levels)` -- pulls the first `num_levels` entries from `result.expect` as a real numpy array of shape `(num_levels, len(tlist))`
- 9 tests covering: self-fidelity=1, orthogonal=0, density matrices, mixed ket/dm, superposition (F=0.5), population shape, values, and real dtype
- Exports both functions from `triqg/__init__.py`

Closes #7
