### PR TITLE
Add solver module: unified mesolve/mcsolve interface with SimulationResult

### DIFF
--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,0 +1,156 @@
+"""Tests for triqg.solver -- unified mesolve/mcsolve interface."""
+
+import numpy as np
+import pytest
+import qutip
+
+from triqg.solver import simulate, SimulationResult
+
+
+# -- Trivial 2-level decay test system --
+# |e> decays to |g> with rate gamma=1.0. No drive.
+H_trivial = qutip.sigmaz()  # static H (just energy splitting)
+psi0_excited = qutip.basis(2, 1)  # start in |e>
+gamma = 1.0
+c_ops_trivial = [np.sqrt(gamma) * qutip.destroy(2)]  # |e> -> |g>
+e_ops_trivial = [
+    qutip.ket2dm(qutip.basis(2, 0)),  # P(|g>)
+    qutip.ket2dm(qutip.basis(2, 1)),
+]  # P(|e>)
+tlist = np.linspace(0, 3, 50)
+
+
+class TestMesolve:
+    def test_returns_simulation_result_with_times(self):
+        result = simulate(
+            method="mesolve",
+            H=H_trivial,
+            psi0=psi0_excited,
+            tlist=tlist,
+            c_ops=c_ops_trivial,
+            e_ops=e_ops_trivial,
+        )
+        assert isinstance(result, SimulationResult)
+        np.testing.assert_array_almost_equal(result.times, tlist)
+
+    def test_expect_has_correct_length_and_decays(self):
+        """Excited state population should decay; ground should increase."""
+        result = simulate(
+            method="mesolve",
+            H=H_trivial,
+            psi0=psi0_excited,
+            tlist=tlist,
+            c_ops=c_ops_trivial,
+            e_ops=e_ops_trivial,
+        )
+        assert len(result.expect) == 2
+        assert len(result.expect[0]) == len(tlist)
+        # P(|e>) should decrease from ~1 to ~0
+        pe = np.real(result.expect[1])
+        assert pe[0] == pytest.approx(1.0, abs=0.05)
+        assert pe[-1] < 0.1
+
+    def test_final_state_is_qobj(self):
+        result = simulate(
+            method="mesolve",
+            H=H_trivial,
+            psi0=psi0_excited,
+            tlist=tlist,
+            c_ops=c_ops_trivial,
+            e_ops=e_ops_trivial,
+            options={"store_final_state": True},
+        )
+        assert isinstance(result.final_state, qutip.Qobj)
+
+    def test_mc_attributes_are_none(self):
+        """mesolve result should return None for MC-specific attributes."""
+        result = simulate(
+            method="mesolve",
+            H=H_trivial,
+            psi0=psi0_excited,
+            tlist=tlist,
+            c_ops=c_ops_trivial,
+            e_ops=e_ops_trivial,
+        )
+        assert result.std_expect is None
+        assert result.num_trajectories is None
+        assert result.col_times is None
+        assert result.col_which is None
+
+
+class TestMcsolve:
+    def test_returns_simulation_result_with_times(self):
+        result = simulate(
+            method="mcsolve",
+            H=H_trivial,
+            psi0=psi0_excited,
+            tlist=tlist,
+            c_ops=c_ops_trivial,
+            e_ops=e_ops_trivial,
+            ntraj=20,
+        )
+        assert isinstance(result, SimulationResult)
+        np.testing.assert_array_almost_equal(result.times, tlist)
+
+    def test_expect_returns_averaged_values(self):
+        """MC expect should be averaged over trajectories and decay like mesolve."""
+        result = simulate(
+            method="mcsolve",
+            H=H_trivial,
+            psi0=psi0_excited,
+            tlist=tlist,
+            c_ops=c_ops_trivial,
+            e_ops=e_ops_trivial,
+            ntraj=50,
+        )
+        assert len(result.expect) == 2
+        pe = np.real(result.expect[1])  # P(|e>)
+        assert pe[0] == pytest.approx(1.0, abs=0.1)
+        assert pe[-1] < 0.2  # should have mostly decayed
+
+    def test_mc_specific_attributes(self):
+        result = simulate(
+            method="mcsolve",
+            H=H_trivial,
+            psi0=psi0_excited,
+            tlist=tlist,
+            c_ops=c_ops_trivial,
+            e_ops=e_ops_trivial,
+            ntraj=10,
+        )
+        # std_expect
+        assert result.std_expect is not None
+        assert len(result.std_expect) == 2
+
+        # num_trajectories
+        assert result.num_trajectories == 10
+
+        # col_times and col_which are lists (one per trajectory)
+        assert result.col_times is not None
+        assert result.col_which is not None
+        assert len(result.col_times) == 10
+
+    def test_final_state_is_qobj(self):
+        result = simulate(
+            method="mcsolve",
+            H=H_trivial,
+            psi0=psi0_excited,
+            tlist=tlist,
+            c_ops=c_ops_trivial,
+            e_ops=e_ops_trivial,
+            ntraj=10,
+            options={"store_final_state": True},
+        )
+        fs = result.final_state
+        assert isinstance(fs, qutip.Qobj)
+
+
+class TestInvalidMethod:
+    def test_raises_on_unknown_method(self):
+        with pytest.raises(ValueError, match="Unknown method"):
+            simulate(
+                method="unknown",
+                H=H_trivial,
+                psi0=psi0_excited,
+                tlist=tlist,
+            )

--- a/triqg/__init__.py
+++ b/triqg/__init__.py
@@ -25,3 +25,5 @@ from .hamiltonian import build_hamiltonian
 from .decoherence import build_collapse_operators
 
 from .analysis import state_fidelity, extract_populations
+
+from .solver import simulate, SimulationResult

--- a/triqg/solver.py
+++ b/triqg/solver.py
@@ -1,0 +1,142 @@
+"""
+Unified solver interface wrapping QuTiP's mesolve and mcsolve.
+
+Provides a single ``simulate()`` entry point that dispatches to the
+appropriate solver and returns a ``SimulationResult`` with a common API.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
+import qutip
+
+
+class SimulationResult:
+    """
+    Thin wrapper around QuTiP solver results with a uniform interface.
+
+    Attributes
+    ----------
+    times : np.ndarray
+    expect : list of np.ndarray
+        For mesolve: direct expect. For mcsolve: average_expect.
+    final_state : qutip.Qobj or None
+    method : str
+        "mesolve" or "mcsolve".
+
+    MC-specific (None for mesolve):
+    std_expect, num_trajectories, col_times, col_which
+    """
+
+    def __init__(self, raw_result, method: str):
+        self._raw = raw_result
+        self.method = method
+
+    @property
+    def times(self) -> np.ndarray:
+        return np.asarray(self._raw.times)
+
+    @property
+    def expect(self) -> list:
+        if self.method == "mcsolve":
+            return self._raw.average_expect
+        return self._raw.expect
+
+    @property
+    def final_state(self) -> Optional[qutip.Qobj]:
+        if self.method == "mcsolve":
+            return self._raw.average_final_state
+        return self._raw.final_state
+
+    # -- MC-specific attributes --
+
+    @property
+    def std_expect(self) -> Optional[list]:
+        if self.method == "mcsolve":
+            return self._raw.std_expect
+        return None
+
+    @property
+    def num_trajectories(self) -> Optional[int]:
+        if self.method == "mcsolve":
+            return self._raw.num_trajectories
+        return None
+
+    @property
+    def col_times(self) -> Optional[list]:
+        if self.method == "mcsolve":
+            return self._raw.col_times
+        return None
+
+    @property
+    def col_which(self) -> Optional[list]:
+        if self.method == "mcsolve":
+            return self._raw.col_which
+        return None
+
+    @property
+    def raw(self):
+        """Access the underlying QuTiP result object."""
+        return self._raw
+
+
+def simulate(
+    method: str,
+    H,
+    psi0: qutip.Qobj,
+    tlist: np.ndarray,
+    c_ops: Optional[list] = None,
+    e_ops: Optional[list] = None,
+    options: Optional[dict] = None,
+    **kwargs,
+) -> SimulationResult:
+    """
+    Run a simulation using mesolve or mcsolve.
+
+    Parameters
+    ----------
+    method : str
+        "mesolve" or "mcsolve".
+    H : Qobj or list
+        Hamiltonian (static or time-dependent list).
+    psi0 : Qobj
+        Initial state (ket or density matrix).
+    tlist : array-like
+        Time points.
+    c_ops : list, optional
+        Collapse operators.
+    e_ops : list, optional
+        Expectation value operators.
+    options : dict, optional
+        Solver options forwarded to QuTiP.
+    **kwargs
+        Additional arguments. For mcsolve: ``ntraj``, ``seeds``,
+        ``target_tol``, ``timeout``.
+
+    Returns
+    -------
+    SimulationResult
+    """
+    c_ops = c_ops or []
+    e_ops = e_ops or []
+
+    if method == "mesolve":
+        raw = qutip.mesolve(H, psi0, tlist, c_ops=c_ops, e_ops=e_ops, options=options)
+    elif method == "mcsolve":
+        ntraj = kwargs.pop("ntraj", 100)
+        raw = qutip.mcsolve(
+            H,
+            psi0,
+            tlist,
+            c_ops=c_ops,
+            e_ops=e_ops,
+            ntraj=ntraj,
+            options=options,
+            **kwargs,
+        )
+    else:
+        raise ValueError(f"Unknown method '{method}'. Use 'mesolve' or 'mcsolve'.")
+
+    return SimulationResult(raw, method=method)


### PR DESCRIPTION
## Summary

- Implements `triqg/solver.py` with unified `simulate(method, H, psi0, tlist, ...)` function
- `method="mesolve"` dispatches to `qutip.mesolve`; `method="mcsolve"` dispatches to `qutip.mcsolve`
- `SimulationResult` wrapper provides common API:
  - `.times` -- time array
  - `.expect` -- expectation values (returns `average_expect` for MC)
  - `.final_state` -- final Qobj (returns `average_final_state` for MC)
  - MC extras: `.std_expect`, `.num_trajectories`, `.col_times`, `.col_which` (None for mesolve)
  - `.raw` -- access the underlying QuTiP result object
- Forwards `ntraj`, `seeds`, solver `options` to QuTiP
- 9 tests using a real 2-level spontaneous decay system:
  - 4 mesolve: times, expect decay, final_state, MC attrs are None
  - 4 mcsolve: times, averaged expect, MC-specific attributes, final_state
  - 1 error: ValueError on unknown method
- Exports `simulate` and `SimulationResult` from `triqg/__init__.py`

Closes #6
