### PR TITLE
Add visualization module: pulse envelopes and population dynamics plots

### DIFF
--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,85 @@
+"""Tests for triqg.visualization -- plotting functions."""
+
+import numpy as np
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")  # non-interactive backend for CI/testing
+import matplotlib.pyplot as plt
+
+from triqg.visualization import plot_pulses, plot_populations, plot_populations_mc
+
+
+# Simple pulse functions for testing
+def _const_pulse(t, args):
+    return 1.0
+
+
+def _zero_pulse(t, args):
+    return 0.0
+
+
+TLIST = np.linspace(0, 1, 20)
+ARGS = {}
+
+
+class TestPlotPulses:
+    def test_returns_axes(self):
+        ax = plot_pulses(TLIST, [_const_pulse, _zero_pulse], ["p1", "p2"], ARGS)
+        assert isinstance(ax, matplotlib.axes.Axes)
+        plt.close("all")
+
+    def test_accepts_existing_ax(self):
+        fig, ax = plt.subplots()
+        returned = plot_pulses(TLIST, [_const_pulse], ["p1"], ARGS, ax=ax)
+        assert returned is ax
+        plt.close("all")
+
+
+class _FakeResult:
+    """Minimal result-like object for testing population plots."""
+
+    def __init__(self, expect, times, std_expect=None):
+        self.expect = expect
+        self.times = times
+        self.std_expect = std_expect
+
+
+class TestPlotPopulations:
+    def test_returns_axes(self):
+        times = np.linspace(0, 1, 10)
+        expect = [np.ones(10), np.zeros(10)]
+        result = _FakeResult(expect, times)
+        ax = plot_populations(result, ["level 0", "level 1"])
+        assert isinstance(ax, matplotlib.axes.Axes)
+        plt.close("all")
+
+    def test_accepts_existing_ax(self):
+        fig, ax = plt.subplots()
+        times = np.linspace(0, 1, 10)
+        expect = [np.ones(10)]
+        result = _FakeResult(expect, times)
+        returned = plot_populations(result, ["level 0"], ax=ax)
+        assert returned is ax
+        plt.close("all")
+
+
+class TestPlotPopulationsMC:
+    def test_returns_axes_with_bands(self):
+        times = np.linspace(0, 1, 10)
+        expect = [np.linspace(1, 0, 10), np.linspace(0, 1, 10)]
+        std = [0.1 * np.ones(10), 0.1 * np.ones(10)]
+        result = _FakeResult(expect, times, std_expect=std)
+        ax = plot_populations_mc(result, ["P(g)", "P(e)"])
+        assert isinstance(ax, matplotlib.axes.Axes)
+        plt.close("all")
+
+    def test_accepts_existing_ax(self):
+        fig, ax = plt.subplots()
+        times = np.linspace(0, 1, 10)
+        expect = [np.ones(10)]
+        std = [0.05 * np.ones(10)]
+        result = _FakeResult(expect, times, std_expect=std)
+        returned = plot_populations_mc(result, ["P(g)"], ax=ax)
+        assert returned is ax
+        plt.close("all")

--- a/triqg/__init__.py
+++ b/triqg/__init__.py
@@ -27,3 +27,5 @@ from .decoherence import build_collapse_operators
 from .analysis import state_fidelity, extract_populations
 
 from .solver import simulate, SimulationResult
+
+from .visualization import plot_pulses, plot_populations, plot_populations_mc

--- a/triqg/visualization.py
+++ b/triqg/visualization.py
@@ -1,0 +1,130 @@
+"""
+Plotting functions for pulse envelopes and population dynamics.
+
+All functions accept an optional ``ax`` argument and return the axes object.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Optional
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+
+
+def plot_pulses(
+    tlist: np.ndarray,
+    pulse_funcs: List[Callable],
+    labels: List[str],
+    args: dict,
+    ax: Optional[Axes] = None,
+) -> Axes:
+    """
+    Plot pulse envelopes versus time.
+
+    Parameters
+    ----------
+    tlist : np.ndarray
+        Time array.
+    pulse_funcs : list of callable
+        Pulse functions with signature ``f(t, args) -> float``.
+    labels : list of str
+        Label for each pulse.
+    args : dict
+        Arguments forwarded to each pulse function.
+    ax : matplotlib Axes, optional
+        Axes to draw on. Created if None.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    if ax is None:
+        _, ax = plt.subplots()
+
+    for func, label in zip(pulse_funcs, labels):
+        values = np.array([func(t, args) for t in tlist])
+        ax.plot(tlist, values, label=label)
+
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Amplitude")
+    ax.set_title("Pulse Envelopes")
+    ax.legend()
+    return ax
+
+
+def plot_populations(
+    result,
+    labels: List[str],
+    ax: Optional[Axes] = None,
+) -> Axes:
+    """
+    Plot population dynamics from a mesolve result.
+
+    Parameters
+    ----------
+    result : object
+        Result with ``.times`` and ``.expect`` attributes.
+        ``result.expect[i]`` is the population of level i over time.
+    labels : list of str
+        Label for each population curve.
+    ax : matplotlib Axes, optional
+        Axes to draw on. Created if None.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    if ax is None:
+        _, ax = plt.subplots()
+
+    times = np.asarray(result.times)
+    for i, label in enumerate(labels):
+        ax.plot(times, np.real(result.expect[i]), label=label)
+
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Population")
+    ax.set_title("Population Dynamics")
+    ax.legend()
+    return ax
+
+
+def plot_populations_mc(
+    result,
+    labels: List[str],
+    ax: Optional[Axes] = None,
+) -> Axes:
+    """
+    Plot averaged population dynamics from an mcsolve result with ±1σ bands.
+
+    Parameters
+    ----------
+    result : object
+        Result with ``.times``, ``.expect``, and ``.std_expect`` attributes.
+    labels : list of str
+        Label for each population curve.
+    ax : matplotlib Axes, optional
+        Axes to draw on. Created if None.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    if ax is None:
+        _, ax = plt.subplots()
+
+    times = np.asarray(result.times)
+    for i, label in enumerate(labels):
+        mean = np.real(result.expect[i])
+        std = np.real(result.std_expect[i])
+        (line,) = ax.plot(times, mean, label=label)
+        ax.fill_between(
+            times, mean - std, mean + std, alpha=0.2, color=line.get_color()
+        )
+
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Population")
+    ax.set_title("Population Dynamics (MC)")
+    ax.legend()
+    return ax


### PR DESCRIPTION
## Summary

- Implements `triqg/visualization.py` with three plotting functions:
  - `plot_pulses(tlist, pulse_funcs, labels, args, ax=None)` -- samples and draws all pulse envelopes on one figure
  - `plot_populations(result, labels, ax=None)` -- draws population curves from mesolve result
  - `plot_populations_mc(result, labels, ax=None)` -- draws MC-averaged populations with shaded +/-1 sigma bands
- All functions accept optional `ax` kwarg and return the matplotlib Axes object
- 6 tests (Agg backend) verifying return type and ax passthrough for all three functions
- Exports all three functions from `triqg/__init__.py`

Closes #8
