### PR TITLE
Add full 8-state CCX truth table verification test

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -11,7 +11,7 @@ from triqg.pulses import omega_c, omega_p, omega_R, compute_pulse_area
 from triqg.hamiltonian import build_hamiltonian, build_ccx_hamiltonian
 from triqg.decoherence import build_collapse_operators
 from triqg.solver import simulate
-from triqg.analysis import state_fidelity, extract_populations
+from triqg.analysis import state_fidelity, extract_populations, average_gate_fidelity
 from triqg.visualization import plot_pulses, plot_populations
 
 
@@ -155,3 +155,99 @@ class TestCCXGatePipelineSmoke:
 
         fid = state_fidelity(result.final_state, psi_target)
         assert 0.0 <= fid <= 1.0
+
+
+class TestCCXTruthTable:
+    """Verify the CCX gate truth table across all 8 computational basis inputs."""
+
+    omega_cc_amp = 2 * np.pi * 100
+    omega_t_amp = 2 * np.pi * 50
+    T_cc = np.pi / omega_cc_amp
+    T_t = np.pi / omega_t_amp
+    V_ct = 2 * np.pi * 200
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        """Build shared Hamiltonian, args, and solver options once."""
+        self.cs = CsAtom()
+        self.rb = RbAtom()
+        self.args = {
+            "omega_cc_amp": self.omega_cc_amp,
+            "omega_t_amp": self.omega_t_amp,
+            "T_cc": self.T_cc,
+            "T_t": self.T_t,
+        }
+        self.H = build_ccx_hamiltonian(self.V_ct)
+        self.t_total = 2 * self.T_cc + 3 * self.T_t
+        self.tlist = np.linspace(0, self.t_total, 5)
+        max_freq = max(self.omega_cc_amp, self.omega_t_amp) / (2 * np.pi)
+        self.max_step = 1.0 / (20 * max_freq)
+
+    def _simulate_state(self, c1_label, c2_label, t_label):
+        """Run CCX simulation for a given input state (no decoherence)."""
+        psi0 = composite_basis_state(
+            self.cs.level_index[c1_label],
+            self.cs.level_index[c2_label],
+            self.rb.level_index[t_label],
+        )
+        result = simulate(
+            method="mesolve",
+            H=self.H,
+            psi0=psi0,
+            tlist=self.tlist,
+            c_ops=[],
+            e_ops=[],
+            options={
+                "store_final_state": True,
+                "nsteps": 100000,
+                "max_step": self.max_step,
+            },
+            args=self.args,
+        )
+        return result.final_state
+
+    # CCX truth table: (c1_in, c2_in, t_in) -> (c1_out, c2_out, t_out)
+    # Only |1,1> controls flip the target; all other control combos leave it unchanged.
+    CCX_TRUTH_TABLE = [
+        ("0", "0", "A", "0", "0", "A"),
+        ("0", "0", "B", "0", "0", "B"),
+        ("0", "1", "A", "0", "1", "A"),
+        ("0", "1", "B", "0", "1", "B"),
+        ("1", "0", "A", "1", "0", "A"),
+        ("1", "0", "B", "1", "0", "B"),
+        ("1", "1", "A", "1", "1", "B"),  # flip
+        ("1", "1", "B", "1", "1", "A"),  # flip
+    ]
+
+    @pytest.mark.parametrize(
+        "c1_in,c2_in,t_in,c1_out,c2_out,t_out",
+        CCX_TRUTH_TABLE,
+        ids=[f"|{c1},{c2},{t}>" for c1, c2, t, *_ in CCX_TRUTH_TABLE],
+    )
+    def test_truth_table_entry(self, c1_in, c2_in, t_in, c1_out, c2_out, t_out):
+        """Each computational basis input maps to the expected CCX output."""
+        final = self._simulate_state(c1_in, c2_in, t_in)
+        expected = composite_basis_state(
+            self.cs.level_index[c1_out],
+            self.cs.level_index[c2_out],
+            self.rb.level_index[t_out],
+        )
+        fid = state_fidelity(final, expected)
+        assert fid > 0.99, (
+            f"Fidelity {fid:.4f} too low for "
+            f"|{c1_in},{c2_in},{t_in}> -> |{c1_out},{c2_out},{t_out}>"
+        )
+
+    def test_average_gate_fidelity(self):
+        """Average fidelity across all 8 basis states is high."""
+        pairs = []
+        for c1_in, c2_in, t_in, c1_out, c2_out, t_out in self.CCX_TRUTH_TABLE:
+            final = self._simulate_state(c1_in, c2_in, t_in)
+            expected = composite_basis_state(
+                self.cs.level_index[c1_out],
+                self.cs.level_index[c2_out],
+                self.rb.level_index[t_out],
+            )
+            pairs.append((final, expected))
+        avg_fid = average_gate_fidelity(pairs)
+        assert avg_fid > 0.99, f"Average gate fidelity {avg_fid:.4f} too low"


### PR DESCRIPTION
## Summary

- Adds `TestCCXTruthTable` to `tests/test_examples.py` — the capstone verification for the CCX gate
- Parametrized test verifies all 8 computational basis inputs against their expected CCX outputs with fidelity > 0.99
- Separate test computes `average_gate_fidelity` across all 8 pairs and asserts > 0.99
- All 9 tests pass in ~1.6s (no decoherence, using `max_step` for QuTiP 5 compatibility)

**CCX truth table verified:**
| Input | Output | Type |
|---|---|---|
| \|0,0,A> | \|0,0,A> | blockade (both controls excited) |
| \|0,0,B> | \|0,0,B> | blockade |
| \|0,1,A> | \|0,1,A> | blockade (c1 excited) |
| \|0,1,B> | \|0,1,B> | blockade |
| \|1,0,A> | \|1,0,A> | blockade (c2 excited) |
| \|1,0,B> | \|1,0,B> | blockade |
| \|1,1,A> | \|1,1,B> | **flip** (no blockade) |
| \|1,1,B> | \|1,1,A> | **flip** (no blockade) |

Closes #24

## Parent PRD

#18